### PR TITLE
Add support with text line starts with square bracket

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,13 +140,16 @@ var Textractor = /** @class */ (function (_super) {
         if (line.indexOf("Usage") === 0)
             return;
         // Handle multiple lines
-        if (line.indexOf("[") === 0) {
-            this.textOutputObject = (scanf_1.sscanf(line, "[%x:%x:%x:%x:%x:%s:%s] %S", "handle", "pid", "addr", "ctx", "ctx2", "name", "code", "text"));
+        // Use regex to match the overhead
+        var regexp = /^\[([0-9A-Fa-f]*):([0-9A-Fa-f]*):([0-9A-Fa-f]*):([0-9A-Fa-f]*):([0-9A-Fa-f]*):(.*)\]/g;
+        var overhead = regexp.exec(line);
+        if (overhead !== null) {
+            this.textOutputObject = (scanf_1.sscanf(overhead[0], "[%x:%x:%x:%x:%x:%s:%s]", "handle", "pid", "addr", "ctx", "ctx2", "name", "code"));
+            this.textOutputObject.text = line.substring(regexp.lastIndex).trim();
             // In case of hook code doesn't exist
             if (this.textOutputObject.name.lastIndexOf(']') === this.textOutputObject.name.length - 1) {
                 this.textOutputObject.name =
                     this.textOutputObject.name.substring(0, this.textOutputObject.name.length - 1);
-                this.textOutputObject.text = this.textOutputObject.code;
                 this.textOutputObject.code = "";
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,26 +167,28 @@ export class Textractor extends EventEmitter {
   private onData(line: string) {
     if (line.indexOf("Usage") === 0) return;
     // Handle multiple lines
-    if (line.indexOf("[") === 0) {
+    // Use regex to match the overhead
+    let regexp = /^\[([0-9A-Fa-f]*):([0-9A-Fa-f]*):([0-9A-Fa-f]*):([0-9A-Fa-f]*):([0-9A-Fa-f]*):(.*)\]/g;
+    let overhead = regexp.exec(line);
+    if (overhead !== null) {
       this.textOutputObject = <TextOutputObject>(
         sscanf(
-          line,
-          "[%x:%x:%x:%x:%x:%s:%s] %S",
+          overhead[0],
+          "[%x:%x:%x:%x:%x:%s:%s]",
           "handle",
           "pid",
           "addr",
           "ctx",
           "ctx2",
           "name",
-          "code",
-          "text"
+          "code"
         )
       );
+      this.textOutputObject.text = line.substring(regexp.lastIndex).trim()
       // In case of hook code doesn't exist
       if (this.textOutputObject.name.lastIndexOf(']') === this.textOutputObject.name.length - 1) {
         this.textOutputObject.name =
             this.textOutputObject.name.substring(0, this.textOutputObject.name.length - 1);
-        this.textOutputObject.text = this.textOutputObject.code;
         this.textOutputObject.code = "";
       }
     } else {

--- a/test/output.spec.js
+++ b/test/output.spec.js
@@ -71,6 +71,32 @@ describe("#output", () => {
     t.onData("わずかな灯りに照らされた道の真ん中で、");
   });
 
+  it("output correct object when content starts with square bracket", done => {
+    let t = new Textractor(validRelativePath);
+    var times = 0;
+    t.on("output", output => {
+      if (++times < 2) {
+        return;
+      }
+      expect(output.handle).to.equal(0x28);
+      expect(output.pid).to.equal(0x08D4);
+      expect(output.addr).to.equal(0x1FF7399AF90);
+      expect(output.ctx).to.equal(0x1FF7399AEC2);
+      expect(output.ctx2).to.equal(0);
+      expect(output.name).to.equal("string");
+      expect(output.text)
+          .to
+          .equal(
+              "それでいて　みちた　つきのように、" +
+              "[カレンダー]:CHECK^1:\"ケン「カレンダーです。\":PAUSE:\"ケン\":\":PAUSE:\"ケン「やはり、ペフルのママの\":\"");
+      done();
+    });
+    t.onData(
+      "[28:8D4:1FF7399AF90:1FF7399AEC2:0:string:ReplaceUnchecked (string,string):HQFX14+-1C@1FF7399AF90] " +
+        "それでいて　みちた　つきのように、");
+    t.onData("[カレンダー]:CHECK^1:\"ケン「カレンダーです。\":PAUSE:\"ケン\":\":PAUSE:\"ケン「やはり、ペフルのママの\":\"");
+  });
+
   it("does not output anything if non-data arrives", done => {
     let somethingOutput = false;
 


### PR DESCRIPTION
## Notes

* Text lines are started with square brackets in some games (e.g.
  Iseshima Story) therefore causing crashes

* Use regexp to match the overhead info accurately (avoiding garbage
  leaking into text in some games, e.g. Iseshima Story)

## Testing
Unit test passed
Test well with YUKI translator on Iseshima Story